### PR TITLE
SectionLede: Forgot to add this max-width

### DIFF
--- a/src/components/SectionLede.tsx
+++ b/src/components/SectionLede.tsx
@@ -26,7 +26,7 @@ const SectionHeading = styled.h2<{ inverse?: boolean }>`
   color: ${(props) => (props.inverse ? color.lightest : color.darkest)};
   flex: 1;
   min-width: 0;
-  max-width: 560px;
+  max-width: 500px;
   text-align: center;
 
   @media (min-width: ${breakpoints[1]}px) {


### PR DESCRIPTION
Minor max-width change
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.1-canary.9.08a038d.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@0.1.1-canary.9.08a038d.0
  # or 
  yarn add @storybook/components-marketing@0.1.1-canary.9.08a038d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
