### PR TITLE
add heading wrapper to SectionLede and remove page margins from Value…

### DIFF
--- a/src/components/SectionLede.stories.tsx
+++ b/src/components/SectionLede.stories.tsx
@@ -19,6 +19,12 @@ Default.args = {
   copy: 'Stories capture the “known good” states of UI components. They’re a pragmatic, reproducible way to keep track of UI edge cases. Reuse stories to power automated tests.',
 };
 
+export const HeadingLevel = Template.bind({});
+HeadingLevel.args = {
+  ...Default.args,
+  headingWrapper: 'h1',
+};
+
 export const WithActions = Template.bind({});
 WithActions.args = {
   heading: 'Build UIs without the grunt work',

--- a/src/components/SectionLede.tsx
+++ b/src/components/SectionLede.tsx
@@ -21,7 +21,10 @@ const ContentContainer = styled.div`
   flex-direction: column;
 `;
 
-const SectionHeading = styled.h2<{ inverse?: boolean }>`
+const SectionHeading = styled.h2<{
+  inverse?: boolean;
+  as?: React.ComponentType | string;
+}>`
   ${marketing.heading};
   color: ${(props) => (props.inverse ? color.lightest : color.darkest)};
   flex: 1;
@@ -82,6 +85,7 @@ interface SectionLedeProps {
   actions?: React.ReactNode;
   meta?: React.ReactNode;
   inverse?: boolean;
+  headingWrapper?: React.ComponentType | string;
 }
 
 export const SectionLede = ({
@@ -90,11 +94,14 @@ export const SectionLede = ({
   heading,
   copy,
   actions,
+  headingWrapper,
   ...props
 }: SectionLedeProps) => (
   <ContentContainer {...props}>
     <ContentWrapper>
-      <SectionHeading inverse={inverse}>{heading}</SectionHeading>
+      <SectionHeading inverse={inverse} as={headingWrapper}>
+        {heading}
+      </SectionHeading>
       <LedeRight>
         <LedeParagraph inverse={inverse}>{copy}</LedeParagraph>
         {actions && <Actions>{actions}</Actions>}

--- a/src/components/ValuePropCopy.tsx
+++ b/src/components/ValuePropCopy.tsx
@@ -3,7 +3,6 @@ import { styled } from '@storybook/theming';
 import { color, pageMargins, breakpoints, marketing, text } from './shared/styles';
 
 const Wrapper = styled.div`
-  ${pageMargins};
   max-width: 320px;
 `;
 


### PR DESCRIPTION
…PropCopy
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.1--canary.16.8647a44.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.0.1--canary.16.8647a44.0
  # or 
  yarn add @storybook/components-marketing@2.0.1--canary.16.8647a44.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
