### PR TITLE
[Do not merge] Fixes for integration

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { global as designSystemGlobal, loadFontsForStorybook } from '@storybook/design-system';
+import '@docsearch/css';
 
 const { GlobalStyle: StorybookDSGlobalStyle } = designSystemGlobal;
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,15 @@ npm install --save @storybook/components-marketing
 
 Install peer dependencies:
 
-- `framer-motion`
-- `@storybook/theming`
+```bash
+npm install --save @docsearch/css @storybook/theming framer-motion
+```
 
 ## Usage — global header and footer
 
-The page header comprises of three parts: [Eyerbrow](src/components/Eyebrow.tsx), [Nav](src/components/Nav) and [SubNav](src/components/SubNav/)
+The page header comprises of three parts: [Eyerbrow](https://main--62acb38c42e6ab9f79be20d5.chromatic.com/?path=/story/eyebrow--default), [Nav](https://main--62acb38c42e6ab9f79be20d5.chromatic.com/?path=/story/nav-nav--default), and [SubNav](https://main--62acb38c42e6ab9f79be20d5.chromatic.com/?path=/story/subnav-subnav--tab-linklist)
 
-`Eyerbrow`, `Nav` and [Footer](src/components/Footer/) usually live at the shared layout level whereas the `SubNav` is specific to each page. The SubNav can be configured in several different ways, check out its [stories file](src/components/SubNav/SubNav.stories.tsx) for examples.
+`Eyebrow`, `Nav`, and [Footer](https://main--62acb38c42e6ab9f79be20d5.chromatic.com/?path=/story/footer-footer--default) usually live at the shared layout level whereas the `SubNav` is specific to each page. The SubNav can be configured in several different ways, check out its [stories file](src/components/SubNav/SubNav.stories.tsx) for examples.
 
 All these components support an `inverse` variant.
 
@@ -60,6 +61,14 @@ Source shared DX data from https://storybook-dx.netlify.app/.netlify/functions/d
 The Nav and Footer links are configured via the [LinksContextProvider](src/components/links-context.ts). It comes with a default set of [links](src/components/links-context.ts#L29)
 
 https://storybook-dx.netlify.app/.netlify/functions/dx-data
+
+### Styling
+
+`Eyebrow` contains a `Search` component which depends on `@docsearch/css`. You need to load these styles in your app, probably at the top-most, global, level:
+
+```js
+import '@docsearch/css';
+```
 
 ## Development Scripts
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     ]
   },
   "dependencies": {
-    "@docsearch/css": "^3.1.0",
     "@docsearch/react": "^3.1.0",
     "@emotion/weak-memoize": "^0.2.5",
     "@floating-ui/react-dom-interactions": "^0.6.5",
@@ -54,7 +53,7 @@
     "@storybook/theming": "^6.5.9",
     "formik": "^2.1.5",
     "human-format": "^0.11.0",
-    "react-merge-refs": "^2.0.0"
+    "react-merge-refs": "^1.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",
@@ -99,6 +98,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
+    "@docsearch/css": "^3.1.0",
     "@storybook/theming": "^6.5.9",
     "framer-motion": "^7.0.0",
     "react": "^15.0.0 || ^16.0.0 || ^17.0.0",

--- a/src/components/CollapsedNav.tsx
+++ b/src/components/CollapsedNav.tsx
@@ -16,7 +16,7 @@ import {
 } from '@floating-ui/react-dom-interactions';
 import { Icon } from '@storybook/design-system';
 import { styled } from '@storybook/theming';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { shadows, color } from './shared/styles';
 import { StackedNav, StackedNavItem } from './StackedNav';
 import { IconButton } from './IconButton';

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -15,7 +15,7 @@ import {
   FloatingFocusManager,
 } from '@floating-ui/react-dom-interactions';
 import { styled } from '@storybook/theming';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { color } from '../shared/styles';
 import { MenuButton } from './MenuButton';
 import { MenuGroup, MenuItem } from './MenuItem';

--- a/src/components/NavMenu/NavMenu.tsx
+++ b/src/components/NavMenu/NavMenu.tsx
@@ -24,7 +24,7 @@ import {
   FloatingFocusManager,
 } from '@floating-ui/react-dom-interactions';
 import { styled } from '@storybook/theming';
-import { mergeRefs } from 'react-merge-refs';
+import mergeRefs from 'react-merge-refs';
 import { color, shadows } from '../shared/styles';
 import { NavMenuButton } from './NavMenuButton';
 

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -3,7 +3,6 @@ import { controlOrMetaKey, shortcutToHumanString } from '@storybook/api/shortcut
 import { css, Global, styled } from '@storybook/theming';
 import { styles } from '@storybook/design-system';
 import { DocSearch } from '@docsearch/react';
-import '@docsearch/css';
 
 // const ALGOLIA_API_KEY = process.env.GATSBY_ALGOLIA_API_KEY;
 const ALGOLIA_API_KEY = 'process.env.GATSBY_ALGOLIA_API_KEY';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1637,7 +1637,7 @@
   resolved "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz#90420f9f9c6d3987f176a19a7d8e764271a2f55d"
   integrity sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==
 
-"@docsearch/css@3.1.0", "@docsearch/css@^3.1.0":
+"@docsearch/css@3.1.0":
   version "3.1.0"
   resolved "https://registry.npmjs.org/@docsearch/css/-/css-3.1.0.tgz#6781cad43fc2e034d012ee44beddf8f93ba21f19"
   integrity sha512-bh5IskwkkodbvC0FzSg1AxMykfDl95hebEKwxNoq4e5QaGzOXSBgW8+jnMFZ7JU4sTBiB04vZWoUSzNrPboLZA==
@@ -12059,15 +12059,10 @@ react-lifecycles-compat@^3.0.0:
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-merge-refs@^1.0.0:
+react-merge-refs@^1.0.0, react-merge-refs@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
   integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
-
-react-merge-refs@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-2.0.0.tgz#4bca0d1bc67bc33723369b5800bb8d3fd75b7b10"
-  integrity sha512-r4oyTTJrwvjNUbbCaKKf4jeOGeQ7o8zwDvqX2u4/iN6w3ooKXFduv5dh2pLNAc7sZ7jLJL/CpsTD7lZVpjPZ7w==
 
 react-modal@^3.11.2:
   version "3.14.3"


### PR DESCRIPTION
- Downgrade `react-merge-refs` to `^1.10`
    - `^2.0.0` is ESM-only (https://github.com/gregberge/react-merge-refs/releases/tag/v2.0.0), making integration in various projects (namely Next.js) difficult at the moment
    - This may cause issues in environments like jest: https://github.com/gregberge/react-merge-refs/issues/16
        - Currently not an issue, as there are no tests
- Remove `@docsearch/css` import from Search
    - Next.js requires all global CSS to be imported in the top-level App component
    - Move it from deps to peerDeps
    - Add instructions to README
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.8--canary.22.778d242.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.0.8--canary.22.778d242.0
  # or 
  yarn add @storybook/components-marketing@2.0.8--canary.22.778d242.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
