### PR TITLE
Fix type of `version` prop for Search

### DIFF
--- a/src/components/Nav/MobileMenu.tsx
+++ b/src/components/Nav/MobileMenu.tsx
@@ -18,7 +18,7 @@ interface MobileMenuProps {
   inverse?: boolean;
   monochrome?: boolean;
   framework: string;
-  version: number;
+  version: string;
   apiKey: string;
 }
 

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -102,7 +102,7 @@ interface NavProps {
   inverse?: boolean;
   monochrome?: boolean;
   framework: string;
-  version: number;
+  version: string;
   apiKey: string;
 }
 
@@ -123,7 +123,7 @@ export const Nav: FunctionComponent<NavProps> = ({
   inverse,
   monochrome,
   framework = 'react',
-  version = 6.5,
+  version = '6.5',
   apiKey,
 }) => {
   const navLinks = useContext(LinksContext);

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -11,7 +11,7 @@ const algoliaDocSearchConfig = {
 
 interface SearchProps {
   framework: string;
-  version: number;
+  version: string;
   className?: string | undefined;
   inverse?: boolean;
   apiKey: string;


### PR DESCRIPTION
- Passing a number means `7.0` is condensed to `7`, when Algolia expects "7.0"
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.10--canary.24.de4d51f.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.0.10--canary.24.de4d51f.0
  # or 
  yarn add @storybook/components-marketing@2.0.10--canary.24.de4d51f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
