### PR TITLE
fix LinkWithWrapper and fetch github stars from dx-data fn

### DIFF
--- a/src/components/Eyebrow.stories.tsx
+++ b/src/components/Eyebrow.stories.tsx
@@ -16,6 +16,7 @@ export const Default = Template.bind({});
 Default.args = {
   label: 'Storybook Lazy Compilation for Webpack',
   link: 'https://storybook.js.org/blog/storybook-lazy-compilation-for-webpack/',
+  githubStarCount: 73724,
 };
 
 export const Inverse = Template.bind({});

--- a/src/components/Eyebrow.tsx
+++ b/src/components/Eyebrow.tsx
@@ -71,10 +71,11 @@ const EyebrowContainer = styled.div<{
 interface EyebrowProps {
   label: string;
   link: string;
+  githubStarCount: number;
   inverse?: boolean;
 }
 
-export const Eyebrow = ({ label, link, inverse }: EyebrowProps) => (
+export const Eyebrow = ({ label, link, inverse, githubStarCount }: EyebrowProps) => (
   <EyebrowContainer inverse={inverse}>
     <Badge status="positive">New</Badge>
     <EyebrowLink inverse={inverse} secondary={!inverse} href={link} withArrow>
@@ -84,7 +85,7 @@ export const Eyebrow = ({ label, link, inverse }: EyebrowProps) => (
       Automate with Chromatic
     </EyebrowCallout>
     <GithubButtonWrapper>
-      <GithubButton />
+      <GithubButton starCount={githubStarCount} />
     </GithubButtonWrapper>
   </EyebrowContainer>
 );

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -29,7 +29,6 @@ const links = {
   componentDriven: { url: 'https://componentdriven.org' },
   guides: { url: '/docs', linkWrapper: FakeGatsbyLink },
   tutorials: { url: 'https://storybook.js.org/tutorials' },
-  api: { url: '/docs/api', linkWrapper: FakeGatsbyLink },
   changelog: { url: '/changelog', linkWrapper: FakeGatsbyLink },
   telemetry: { url: '/telemetry', linkWrapper: FakeGatsbyLink },
   showcase: { url: 'https://storybook.js.org/showcase' },

--- a/src/components/Footer/Footer.styles.ts
+++ b/src/components/Footer/Footer.styles.ts
@@ -1,6 +1,5 @@
 import { styled } from '@storybook/theming';
 import { Button, Link, Subheading } from '@storybook/design-system';
-import { ComponentProps } from 'react';
 import {
   background,
   color,

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -23,7 +23,6 @@ const footerGroups = (links: Links) => ({
   docs: [
     { label: 'Guides', link: links.guides },
     { label: 'Tutorials', link: links.tutorials },
-    { label: 'API', link: links.api },
     { label: 'Changelog', link: links.changelog },
     { label: 'Telemetry', link: links.telemetry },
   ],

--- a/src/components/GithubButton.stories.tsx
+++ b/src/components/GithubButton.stories.tsx
@@ -6,4 +6,4 @@ export default {
   component: GithubButton,
 };
 
-export const Basic = (args) => <GithubButton {...args} />;
+export const Basic = (args) => <GithubButton starCount={73724} />;

--- a/src/components/GithubButton.tsx
+++ b/src/components/GithubButton.tsx
@@ -97,50 +97,35 @@ const Wrapper = styled.div`
   display: flex;
 `;
 
-export const GithubButton = () => {
-  const [starCount, setStarCount] = useState('');
-
-  useEffect(() => {
-    fetch('https://api.github.com/repos/storybookjs/storybook', {
-      referrerPolicy: 'strict-origin-when-cross-origin',
-    })
-      .then((res) => res.json())
-      .then((data) => {
-        setStarCount(data.stargazers_count);
-      })
-      .catch((error) => console.error(error));
-  });
-
-  return (
-    <Wrapper className="chromatic-ignore">
-      <Star
-        href="https://github.com/storybookjs/storybook"
-        rel="noopener"
-        target="_blank"
-        aria-label="Star Storybook on GitHub"
+export const GithubButton = ({ starCount }: { starCount: number }) => (
+  <Wrapper className="chromatic-ignore">
+    <Star
+      href="https://github.com/storybookjs/storybook"
+      rel="noopener"
+      target="_blank"
+      aria-label="Star Storybook on GitHub"
+    >
+      <Svg
+        viewBox="0 0 16 16"
+        width="14"
+        height="14"
+        className="octicon octicon-mark-github"
+        aria-hidden="true"
       >
-        <Svg
-          viewBox="0 0 16 16"
-          width="14"
-          height="14"
-          className="octicon octicon-mark-github"
-          aria-hidden="true"
-        >
-          <path
-            fillRule="evenodd"
-            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
-          />
-        </Svg>
-        <span>Star</span>
-      </Star>
-      <Count
-        href="https://github.com/storybookjs/storybook/stargazers"
-        rel="noopener"
-        target="_blank"
-        aria-label={`${starCount} stargazers on GitHub`}
-      >
-        {starCount.toLocaleString()}
-      </Count>
-    </Wrapper>
-  );
-};
+        <path
+          fillRule="evenodd"
+          d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+        />
+      </Svg>
+      <span>Star</span>
+    </Star>
+    <Count
+      href="https://github.com/storybookjs/storybook/stargazers"
+      rel="noopener"
+      target="_blank"
+      aria-label={`${starCount} stargazers on GitHub`}
+    >
+      {starCount.toLocaleString()}
+    </Count>
+  </Wrapper>
+);

--- a/src/components/IntegrationsCarousel.stories.tsx
+++ b/src/components/IntegrationsCarousel.stories.tsx
@@ -79,7 +79,6 @@ export const Default = Template.bind({});
 Default.args = {
   integrations: 'Default',
   overflowLabel: '+ and more',
-  aspectRatio: 1202 / 910,
 };
 Default.parameters = {
   chromatic: { disableSnapshot: true },

--- a/src/components/LinkWithWrapper.tsx
+++ b/src/components/LinkWithWrapper.tsx
@@ -14,7 +14,7 @@ export const LinkWithWrapper = forwardRef<HTMLAnchorElement, LinkWithWrapperProp
   ({ children, href, LinkWrapper, ...props }, ref) => {
     if (LinkWrapper) {
       return (
-        <LinkWrapper to={href} ref={ref} {...props}>
+        <LinkWrapper href={href} ref={ref} {...props}>
           {children}
         </LinkWrapper>
       );

--- a/src/components/Nav/Nav.stories.tsx
+++ b/src/components/Nav/Nav.stories.tsx
@@ -29,7 +29,6 @@ const navLinks = {
   componentDriven: { url: 'https://componentdriven.org' },
   guides: { url: '/docs', linkWrapper: FakeGatsbyLink },
   tutorials: { url: 'https://storybook.js.org/tutorials' },
-  api: { url: '/docs/api', linkWrapper: FakeGatsbyLink },
   changelog: { url: '/changelog', linkWrapper: FakeGatsbyLink },
   telemetry: { url: '/telemetry', linkWrapper: FakeGatsbyLink },
   showcase: { url: 'https://storybook.js.org/showcase' },
@@ -74,6 +73,7 @@ export const FullStack = () => (
     <Eyebrow
       label="Storybook Lazy Compilation for Webpack"
       link="https://storybook.js.org/blog/storybook-lazy-compilation-for-webpack/"
+      githubStarCount={73724}
     />
     <Nav apiKey="ALGOLIA_API_KEY" framework="react" version="6.5" />
     <SubNav>

--- a/src/components/links-context.ts
+++ b/src/components/links-context.ts
@@ -11,7 +11,6 @@ export interface Links {
   componentDriven: LinkItem;
   guides: LinkItem;
   tutorials: LinkItem;
-  api: LinkItem;
   changelog: LinkItem;
   telemetry: LinkItem;
   showcase: LinkItem;
@@ -29,7 +28,6 @@ export const defaultLinks = {
   componentDriven: { url: 'https://componentdriven.org' },
   guides: { url: '/docs' },
   tutorials: { url: 'https://storybook.js.org/tutorials' },
-  api: { url: '/docs/api' },
   changelog: { url: 'https://storybook.js.org/changelog' },
   telemetry: { url: 'https://storybook.js.org/telemetry' },
   showcase: { url: 'https://storybook.js.org/showcase' },


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.14--canary.28.ae4b3d7.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.0.14--canary.28.ae4b3d7.0
  # or 
  yarn add @storybook/components-marketing@2.0.14--canary.28.ae4b3d7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
