### PR TITLE
Add `inverse` support to SubNavLinkList

### DIFF
--- a/src/components/SubNav/SubNav.stories.tsx
+++ b/src/components/SubNav/SubNav.stories.tsx
@@ -137,6 +137,21 @@ export const BreadcrumbLinklist = () => (
   </SubNav>
 );
 
+export const BreadcrumbLinklistInverse = () => (
+  <SubNav inverse>
+    <SubNavBreadcrumb tertiary href="/back" inverse>
+      <Icon icon="arrowleft" />
+      Back to blog
+    </SubNavBreadcrumb>
+    <SubNavRight>
+      <SubNavLinkList label="Join the community:" items={communityItems} inverse />
+    </SubNavRight>
+  </SubNav>
+);
+BreadcrumbLinklistInverse.parameters = {
+  backgrounds: { default: 'dark' },
+};
+
 export const BreadcrumbCTA = () => (
   <SubNav>
     <SubNavBreadcrumb tertiary href="/back">

--- a/src/components/SubNav/SubNavLinkList.tsx
+++ b/src/components/SubNav/SubNavLinkList.tsx
@@ -4,9 +4,11 @@ import { styled } from '@storybook/theming';
 import { Link, LinkProps, Icon } from '@storybook/design-system';
 import { text, color } from '../shared/styles';
 
-const SubNavLinkListContainer = styled.nav`
+const SubNavLinkListContainer = styled('nav', {
+  shouldForwardProp: (prop) => !['inverse'].includes(prop),
+})<Pick<SubNavLinkListProps, 'inverse'>>`
   ${text.regular};
-  color: ${color.dark};
+  color: ${(props) => (props.inverse ? color.medium : color.dark)};
   display: flex;
   align-items: center;
   margin-top: 10px;
@@ -16,6 +18,12 @@ const SubNavLinkListContainer = styled.nav`
   a {
     margin-left: 10px;
   }
+`;
+
+const StyledIcon = styled(Icon, {
+  shouldForwardProp: (prop) => !['inverse'].includes(prop),
+})<Pick<SubNavLinkListProps, 'inverse'>>`
+  color: ${(props) => (props.inverse ? color.light : color.dark)};
 `;
 
 export type SubNavLinkItem = {
@@ -28,17 +36,22 @@ export type SubNavLinkItem = {
 interface SubNavLinkListProps {
   label: string;
   items: SubNavLinkItem[];
+  inverse?: boolean;
 }
 
-export const SubNavLinkList: FunctionComponent<SubNavLinkListProps> = ({ label, items }) => {
+export const SubNavLinkList: FunctionComponent<SubNavLinkListProps> = ({
+  label,
+  items,
+  inverse,
+}) => {
   const id = useId();
 
   return (
-    <SubNavLinkListContainer aria-labelledby={id}>
+    <SubNavLinkListContainer aria-labelledby={id} inverse={inverse}>
       <div id={id}>{label}</div>
       {items.map((item) => (
         <Link key={item.label} tertiary containsIcon href={item.href} aria-label={item.label}>
-          <Icon icon={item.icon} aria-hidden />
+          <StyledIcon icon={item.icon} aria-hidden inverse={inverse} />
         </Link>
       ))}
     </SubNavLinkListContainer>


### PR DESCRIPTION
![Screenshot of subnav inversed, featuring the affected component](https://user-images.githubusercontent.com/486540/189408924-f3d10cdb-6570-4097-87f2-df67ab414767.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.1.0--canary.35.23d8099.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.1.0--canary.35.23d8099.0
  # or 
  yarn add @storybook/components-marketing@2.1.0--canary.35.23d8099.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
