### PR TITLE
Fix visual bugs

### DIFF
--- a/src/components/NotFoundScreen/PuzzlePieces.tsx
+++ b/src/components/NotFoundScreen/PuzzlePieces.tsx
@@ -730,6 +730,7 @@ export const PuzzlePieces = () => {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       animate={rippleControls}
+      data-chromatic="ignore"
     >
       {shapes.map(({ id, x, y, path, color }, index) => (
         <Shape

--- a/src/components/SubNav/SubNavLinkList.tsx
+++ b/src/components/SubNav/SubNavLinkList.tsx
@@ -8,7 +8,7 @@ const SubNavLinkListContainer = styled('nav', {
   shouldForwardProp: (prop) => !['inverse'].includes(prop),
 })<Pick<SubNavLinkListProps, 'inverse'>>`
   ${text.regular};
-  color: ${(props) => (props.inverse ? color.medium : color.dark)};
+  color: ${(props) => (props.inverse ? color.light : color.dark)};
   display: flex;
   align-items: center;
   margin-top: 10px;


### PR DESCRIPTION
- Fix color of SubNavLinkList label when `inverse={true}`
- Add `data-chromatic="ignore"` to PuzzlePieces, as the animation is non-deterministic
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.22--canary.36.c67ba3d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.0.22--canary.36.c67ba3d.0
  # or 
  yarn add @storybook/components-marketing@2.0.22--canary.36.c67ba3d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
