### PR TITLE
Visual tweak of social card button + cardinal spacing

### DIFF
--- a/src/components/SocialCard.tsx
+++ b/src/components/SocialCard.tsx
@@ -24,7 +24,7 @@ const Description = styled.p<{ inverse?: boolean }>`
 `;
 
 const LinkButton = styled(Button)`
-  margin-bottom: 20px;
+  margin-bottom: 24px;
 `;
 
 const Stat = styled(Cardinal)<{ inverse?: boolean }>`


### PR DESCRIPTION
Bumps up spacing by 4px 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.29--canary.43.7e3b321.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.0.29--canary.43.7e3b321.0
  # or 
  yarn add @storybook/components-marketing@2.0.29--canary.43.7e3b321.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
