### PR TITLE
Fix autoplay for videos

### DIFF
--- a/src/components/IllustratedFeatureList.tsx
+++ b/src/components/IllustratedFeatureList.tsx
@@ -298,6 +298,7 @@ export const IllustratedFeatureList = ({
               autoPlay
               loop
               playsInline
+              muted
               poster={activeFeature.poster}
             />
           </MotionDivDesktop>


### PR DESCRIPTION
Fixes autoplay for Document and Test videos

@winkerVSbecks can you review and update the package in the frontpage?
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.40--canary.54.89c863a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.0.40--canary.54.89c863a.0
  # or 
  yarn add @storybook/components-marketing@2.0.40--canary.54.89c863a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
