### PR TITLE
Update default links

### DIFF
--- a/src/components/links-context.ts
+++ b/src/components/links-context.ts
@@ -33,7 +33,7 @@ export const defaultLinks = {
   showcase: { url: 'https://storybook.js.org/showcase' },
   projects: { url: 'https://storybook.js.org/showcase/projects' },
   componentGlossary: { url: 'https://storybook.js.org/showcase/glossary' },
-  integrations: { url: 'https://storybook.js.org/addons' },
+  integrations: { url: 'https://storybook.js.org/integrations' },
   getInvolved: { url: 'https://storybook.js.org/community' },
   blog: { url: 'https://storybook.js.org/blog' },
   hiring: { url: 'https://www.chromatic.com/company/jobs' },


### PR DESCRIPTION
Update the default link for integrations in the footer
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.41--canary.55.2979e5e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.0.41--canary.55.2979e5e.0
  # or 
  yarn add @storybook/components-marketing@2.0.41--canary.55.2979e5e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
