### PR TITLE
Update `whyStorybook` URL

### DIFF
--- a/src/components/links-context.ts
+++ b/src/components/links-context.ts
@@ -25,7 +25,7 @@ export interface Links {
 
 export const defaultLinks = {
   home: { url: 'https://storybook.js.org/' },
-  whyStorybook: { url: 'https://storybook.js.org/docs/react/why-storybook' },
+  whyStorybook: { url: 'https://storybook.js.org/docs/react/get-started/why-storybook' },
   componentDriven: { url: 'https://componentdriven.org' },
   guides: { url: 'https://storybook.js.org/docs' },
   tutorials: { url: 'https://storybook.js.org/tutorials' },


### PR DESCRIPTION
Because of https://github.com/storybookjs/storybook/pull/21393

DO NOT MERGE until after:
1. https://github.com/storybookjs/storybook/pull/21393
2. https://github.com/storybookjs/frontpage/pull/494

After merging, ensure various SB sub-sites are rebuilt with newest version of this package
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.45--canary.61.049d63f.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.0.45--canary.61.049d63f.0
  # or 
  yarn add @storybook/components-marketing@2.0.45--canary.61.049d63f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
