### PR TITLE
Fix NavMenu styles

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -16,7 +16,7 @@ import {
 } from '@floating-ui/react-dom-interactions';
 import { styled } from '@storybook/theming';
 import mergeRefs from 'react-merge-refs';
-import { color } from '../shared/styles';
+import { color, shadows } from '../shared/styles';
 import { MenuButton } from './MenuButton';
 import { MenuGroup, MenuItem } from './MenuItem';
 
@@ -28,7 +28,7 @@ export const MenuPanel = styled.div`
   background: ${color.lightest};
   border-radius: 4px;
 
-  box-shadow: 0px 0px 15px ${color.tr5}, 0px 1px 2px ${color.tr10};
+  ${shadows.tooltip};
 `;
 
 interface MenuItemProps {

--- a/src/components/NavMenu/NavMenu.tsx
+++ b/src/components/NavMenu/NavMenu.tsx
@@ -31,8 +31,6 @@ import { NavMenuButton } from './NavMenuButton';
 export const NavMenuPanel = styled(MenuPanel)`
   padding: 12px;
   width: 288px;
-
-  border-radius: 5px;
 `;
 
 interface NavMenuProps {

--- a/src/components/NavMenu/NavMenu.tsx
+++ b/src/components/NavMenu/NavMenu.tsx
@@ -25,17 +25,14 @@ import {
 } from '@floating-ui/react-dom-interactions';
 import { styled } from '@storybook/theming';
 import mergeRefs from 'react-merge-refs';
-import { color, shadows } from '../shared/styles';
+import { MenuPanel } from '../Menu/Menu';
 import { NavMenuButton } from './NavMenuButton';
 
-export const NavMenuPanel = styled.div`
+export const NavMenuPanel = styled(MenuPanel)`
   padding: 12px;
   width: 288px;
 
-  background: ${color.lightest};
   border-radius: 5px;
-
-  ${shadows.tooltip};
 `;
 
 interface NavMenuProps {


### PR DESCRIPTION
- NavMenuPanel now composes MenuPanel
    - Mostly so that it receive's MenuPanel's `z-index` value

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.45--canary.62.61a6d98.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.0.45--canary.62.61a6d98.0
  # or 
  yarn add @storybook/components-marketing@2.0.45--canary.62.61a6d98.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
