### PR TITLE
reduce z-index for drawer to show search on mobile

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -15,7 +15,7 @@ import { IconButton } from './IconButton';
 
 const AnimatedOverlay = styled(motion(FloatingOverlay))`
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-  z-index: 999999;
+  z-index: 100;
 `;
 
 interface DrawerProps {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.47--canary.65.168c43c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.0.47--canary.65.168c43c.0
  # or 
  yarn add @storybook/components-marketing@2.0.47--canary.65.168c43c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
