### PR TITLE
Tweak header, remove SB Day

### DIFF
--- a/src/components/Eyebrow.tsx
+++ b/src/components/Eyebrow.tsx
@@ -108,11 +108,8 @@ export const Eyebrow = ({ label, link, inverse, githubStarCount }: EyebrowProps)
       inverse={inverse}
       href="https://www.chromatic.com?utm_source=storybook_website&utm_medium=link&utm_campaign=storybook"
     >
-      Automate with Chromatic
+      Visual test with Chromatic
     </EyebrowCallout>
-    <StorybookDayLink href="https://storybook.js.org/day">
-      <Badge status="selected">Storybook Day 2023</Badge>
-    </StorybookDayLink>
     <GithubButtonWrapper>
       <GithubButton starCount={githubStarCount} />
     </GithubButtonWrapper>


### PR DESCRIPTION
- Remove Storybook Day badge
- Change “automate with Chromatic” to “Visual test with Chromatic”
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.48--canary.66.bd88fc6.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.0.48--canary.66.bd88fc6.0
  # or 
  yarn add @storybook/components-marketing@2.0.48--canary.66.bd88fc6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
