### PR TITLE
Add z-index to mobile nav to make sure it always sit on top.

### DIFF
--- a/src/components/CollapsedNav.tsx
+++ b/src/components/CollapsedNav.tsx
@@ -31,6 +31,8 @@ export const CollapsedNavPanel = styled.div`
   outline: 0;
 
   ${shadows.tooltip}
+
+  z-index: 20;
 `;
 
 interface MenuItem {


### PR DESCRIPTION
On the docs, the main navigation is fixed. To make sure the nav mobile is always on top, we need to add a `z-index` to it.

![CleanShot 2023-11-13 at 22 07 23@2x](https://github.com/storybookjs/components-marketing/assets/1540635/552f50f6-5755-4738-bf55-3aa3c25bd234)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.1.4--canary.72.a7751f0.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.1.4--canary.72.a7751f0.0
  # or 
  yarn add @storybook/components-marketing@2.1.4--canary.72.a7751f0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
