### PR TITLE
Remove jobs board and conferences board from Header and Footer

### DIFF
--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -39,12 +39,6 @@ const links = {
   getInvolved: { url: '/community', linkWrapper: FakeGatsbyLink },
   blog: { url: 'https://storybook.js.org/blog' },
   hiring: { url: 'https://www.chromatic.com/company/jobs' },
-  jobsBoard: {
-    url: 'https://chromatic-ui.notion.site/Storybook-Jobs-Board-950e001e4a114a39980a5b09c3a3b3e1?pvs=4',
-  },
-  conferenceBoard: {
-    url: 'https://chromatic-ui.notion.site/Give-a-conference-talk-about-Storybook-e8d8e78d4d0a448a811a8d927194c527?pvs=4',
-  },
 };
 
 const Template = (args) => (

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -31,8 +31,6 @@ const footerGroups = (links: Links) => ({
     { label: 'Integrations', link: links.integrations },
     { label: 'Get involved', link: links.getInvolved },
     { label: 'Blog', link: links.blog },
-    { label: 'Find jobs', link: links.jobsBoard },
-    { label: 'Speak at conferences', link: links.conferenceBoard },
   ],
   showcase: [
     { label: 'Explore', link: links.showcase },

--- a/src/components/Nav/Nav.stories.tsx
+++ b/src/components/Nav/Nav.stories.tsx
@@ -39,12 +39,6 @@ const navLinks = {
   getInvolved: { url: '/community', linkWrapper: FakeGatsbyLink },
   blog: { url: 'https://storybook.js.org/blog' },
   hiring: { url: 'https://www.chromatic.com/company/jobs' },
-  jobsBoard: {
-    url: 'https://chromatic-ui.notion.site/Storybook-Jobs-Board-950e001e4a114a39980a5b09c3a3b3e1?pvs=4',
-  },
-  conferenceBoard: {
-    url: 'https://chromatic-ui.notion.site/Give-a-conference-talk-about-Storybook-e8d8e78d4d0a448a811a8d927194c527?pvs=4',
-  },
 };
 
 const Template = (args) => (

--- a/src/components/Nav/menus.tsx
+++ b/src/components/Nav/menus.tsx
@@ -7,6 +7,35 @@ interface Menu extends ComponentProps<typeof NavMenu> {
   navLinks: Links;
 }
 
+export const Docs = ({ active, inverse, monochrome, navLinks }: Menu) => (
+  <NavMenu label="Docs" inverse={inverse} monochrome={monochrome} active={active}>
+    <NavMenuItem
+      icon={<ColoredIcon icon="book" color="green" />}
+      description="Learn everything you need to know to use Storybook"
+      href={navLinks.guides.url}
+      LinkWrapper={navLinks.guides.linkWrapper}
+    >
+      Guides
+    </NavMenuItem>
+    <NavMenuItem
+      icon={<ColoredIcon icon="compass" color="gold" />}
+      description="Follow guided walkthroughs on for Storybook’s key workflows"
+      href={navLinks.tutorials.url}
+      LinkWrapper={navLinks.tutorials.linkWrapper}
+    >
+      Tutorials
+    </NavMenuItem>
+    <NavMenuItem
+      icon={<ColoredIcon icon="verified" color="green" />}
+      description="Release notes for all major and minor Storybook versions"
+      href={navLinks.changelog.url}
+      LinkWrapper={navLinks.changelog.linkWrapper}
+    >
+      Changelog
+    </NavMenuItem>
+  </NavMenu>
+);
+
 export const Community = ({ active, inverse, monochrome, navLinks }: Menu) => (
   <NavMenu label="Community" inverse={inverse} monochrome={monochrome} active={active}>
     <NavMenuItem
@@ -24,22 +53,6 @@ export const Community = ({ active, inverse, monochrome, navLinks }: Menu) => (
       LinkWrapper={navLinks.blog.linkWrapper}
     >
       Blog and updates
-    </NavMenuItem>
-    <NavMenuItem
-      icon={<ColoredIcon icon="bookmarkhollow" color="seafoam" />}
-      description="Browse job board for roles that use Storybook"
-      href={navLinks.jobsBoard.url}
-      LinkWrapper={navLinks.jobsBoard.linkWrapper}
-    >
-      Find jobs
-    </NavMenuItem>
-    <NavMenuItem
-      icon={<ColoredIcon icon="globe" color="secondary" />}
-      description="Submit talks to conferences about Storybook"
-      href={navLinks.conferenceBoard.url}
-      LinkWrapper={navLinks.conferenceBoard.linkWrapper}
-    >
-      Speak at conferences
     </NavMenuItem>
   </NavMenu>
 );
@@ -117,16 +130,6 @@ export const mobileGroups = (links: Links) => [
         label: 'Blog',
         link: links.blog,
         icon: <ColoredIcon icon="rss" color="purple" />,
-      },
-      {
-        label: 'Jobs board',
-        link: links.jobsBoard,
-        icon: <ColoredIcon icon="bookmarkhollow" color="seafoam" />,
-      },
-      {
-        label: 'Conference board',
-        link: links.conferenceBoard,
-        icon: <ColoredIcon icon="globe" color="secondary" />,
       },
     ],
   },

--- a/src/components/links-context.ts
+++ b/src/components/links-context.ts
@@ -23,8 +23,6 @@ export interface Links {
   hiring: LinkItem;
   enterprise: LinkItem;
   chromatic: LinkItem;
-  jobsBoard: LinkItem;
-  conferenceBoard: LinkItem;
 }
 
 export const defaultLinks = {
@@ -43,12 +41,6 @@ export const defaultLinks = {
   getInvolved: { url: 'https://storybook.js.org/community' },
   blog: { url: 'https://storybook.js.org/blog' },
   hiring: { url: 'https://www.chromatic.com/company/jobs' },
-  jobsBoard: {
-    url: 'https://chromatic-ui.notion.site/Storybook-Jobs-Board-950e001e4a114a39980a5b09c3a3b3e1?pvs=4',
-  },
-  conferenceBoard: {
-    url: 'https://chromatic-ui.notion.site/Give-a-conference-talk-about-Storybook-e8d8e78d4d0a448a811a8d927194c527?pvs=4',
-  },
   enterprise: {
     url: 'https://www.chromatic.com/sales?utm_source=storybook_website&utm_medium=link&utm_campaign=storybook',
   },


### PR DESCRIPTION
We're discontinuing these initiatives as Joe is focusing on other things.

heads up @winkerVSbecks we'll have to update the package in sb/frontpage for this to take effect

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.2.1--canary.73.d78807a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.2.1--canary.73.d78807a.0
  # or 
  yarn add @storybook/components-marketing@2.2.1--canary.73.d78807a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
