### PR TITLE
Fix global navigation for the new homepage for SB8

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@storybook/manager-webpack5": "^6.5.10",
     "@storybook/react": "^6.5.9",
     "@storybook/testing-library": "^0.0.13",
-    "auto": "^10.37.4",
+    "auto": "^11.1.1",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
     "chromatic": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@floating-ui/react-dom-interactions": "^0.6.5",
     "@storybook/api": "^6.5.9",
     "@storybook/design-system": "^7.9.0",
+    "@storybook/icons": "^1.2.8",
     "@storybook/theming": "^6.5.9",
     "formik": "^2.1.5",
     "human-format": "^0.11.0",

--- a/src/components/Eyebrow.tsx
+++ b/src/components/Eyebrow.tsx
@@ -85,7 +85,7 @@ export const Eyebrow = ({ label, link, inverse, githubStarCount }: EyebrowProps)
       Visual test with Chromatic
     </EyebrowCallout>
     <GithubButtonWrapper>
-      <GithubButton starCount={githubStarCount} />
+      <GithubButton starCount={githubStarCount} inverse={inverse} />
     </GithubButtonWrapper>
   </EyebrowContainer>
 );

--- a/src/components/Eyebrow.tsx
+++ b/src/components/Eyebrow.tsx
@@ -33,6 +33,8 @@ const EyebrowCallout = styled(Link)<{ inverse?: boolean }>`
 const EyebrowContainer = styled.div<{
   inverse?: boolean;
 }>`
+  position: relative;
+  z-index: 20;
   display: none;
   align-items: center;
   padding: ${spacing.padding.small}px ${spacing.padding.medium}px;

--- a/src/components/Eyebrow.tsx
+++ b/src/components/Eyebrow.tsx
@@ -38,7 +38,7 @@ const EyebrowContainer = styled.div<{
   display: none;
   align-items: center;
   padding: ${spacing.padding.small}px ${spacing.padding.medium}px;
-  background-color: ${(props) => (props.inverse ? 'rgba(0, 0, 0, 0.3)' : color.blueLight)};
+  background-color: ${(props) => (props.inverse ? 'rgba(0, 0, 0, 0.1)' : color.blueLight)};
   box-shadow: ${(props) => (props.inverse ? 'rgba(255, 255, 255, 0.1)' : color.tr10)} 0 -1px 0px 0px
     inset;
 

--- a/src/components/Footer/Footer.styles.ts
+++ b/src/components/Footer/Footer.styles.ts
@@ -12,6 +12,8 @@ import {
 const inverseBorder = 'rgba(255, 255, 255, 0.1)';
 
 export const FooterWrapper = styled.footer<{ inverse?: boolean }>`
+  position: relative;
+  z-index: 10;
   background-color: ${(props) => (props.inverse ? '#0E0C2A' : background.app)};
   border-top: 1px solid ${(props) => (props.inverse ? inverseBorder : color.border)};
   padding-top: 3rem;

--- a/src/components/Footer/Footer.styles.ts
+++ b/src/components/Footer/Footer.styles.ts
@@ -12,7 +12,7 @@ import {
 const inverseBorder = 'rgba(255, 255, 255, 0.1)';
 
 export const FooterWrapper = styled.footer<{ inverse?: boolean }>`
-  background-color: ${(props) => (props.inverse ? color.midnight : background.app)};
+  background-color: ${(props) => (props.inverse ? '#0E0C2A' : background.app)};
   border-top: 1px solid ${(props) => (props.inverse ? inverseBorder : color.border)};
   padding-top: 3rem;
   padding-bottom: 3rem;

--- a/src/components/GithubButton.tsx
+++ b/src/components/GithubButton.tsx
@@ -1,7 +1,23 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { styled } from '@storybook/theming';
+import { styles } from '@storybook/design-system';
 
-const Svg = styled.svg`
+const Wrapper = styled.div<{ inverse?: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(27, 31, 36, 0.15);
+  /* border: props.inverse ? 'rgba(255, 255, 255, 0.2)' : styles.color.border */
+  border: ${(props) =>
+    `1px solid ${props.inverse ? 'rgba(255, 255, 255, 0.2)' : styles.color.border}`};
+  height: 32px;
+  border-radius: 64px;
+  cursor: pointer;
+  gap: 10px;
+  padding: 0 8px;
+`;
+
+const Svg = styled.svg<{ inverse?: boolean }>`
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif;
   white-space: nowrap;
   font-size: 11px;
@@ -9,14 +25,13 @@ const Svg = styled.svg`
   line-height: 14px;
   cursor: pointer;
   user-select: none;
-  color: #24292f;
+  color: ${(props) => (props.inverse ? styles.color.lightest : '#24292f')};
   width: 14;
   height: 14;
   display: inline-block;
   vertical-align: text-top;
   fill: currentColor;
   overflow: visible;
-  margin-right: 4px;
 `;
 
 const Star = styled.a`
@@ -27,78 +42,38 @@ const Star = styled.a`
   position: relative;
   display: inline-flex;
   height: 14px;
-  padding: 2px 5px;
   font-size: 11px;
   font-weight: 600;
   line-height: 14px;
   vertical-align: bottom;
-  cursor: pointer;
   user-select: none;
-  background-repeat: repeat-x;
-  background-position: -1px -1px;
-  background-size: 110% 110%;
-  border: 1px solid rgba(27, 31, 36, 0.15);
-  color: #24292f;
-  background-color: #ebf0f4;
-  background-image: linear-gradient(180deg, #f6f8fa, #ebf0f4 90%);
-  border-radius: 0.25em 0 0 0.25em;
-
-  &:focus,
-  &:hover {
-    background-color: #e9ebef;
-    background-position: 0 -0.5em;
-    background-image: url(
-      data:image/svg + xml,
-      %3csvgxmlns='http://www.w3.org/2000/svg'%3e%3clinearGradientid='o'x2='0'y2='1'%3e%3cstopstop-color='%23f3f4f6'/%3e%3cstopoffset='90%25'stop-color='%23e9ebef'/%3e%3c/linearGradient%3e%3crectwidth='100%25'height='100%25'fill='url(%23o)'/%3e%3c/svg%3e
-    );
-    background-image: linear-gradient(180deg, #f3f4f6, #e9ebef 90%);
-  }
-
-  &:active {
-    background-color: #e5e9ed;
-    box-shadow: inset 0 0.15em 0.3em rgb(27 31 36 / 15%);
-    background-image: none;
-  }
 `;
 
-const Count = styled.a`
+const Count = styled.a<{ inverse?: boolean }>`
   box-sizing: content-box;
   text-align: left;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   text-decoration: none;
-  position: relative;
-  display: inline-flex;
   height: 14px;
-  padding: 2px 5px;
   font-size: 11px;
   font-weight: 600;
   line-height: 14px;
   vertical-align: bottom;
   cursor: pointer;
   user-select: none;
-  background-repeat: repeat-x;
-  background-position: -1px -1px;
-  background-size: 110% 110%;
-  border: 1px solid rgba(27, 31, 36, 0.15);
-  border-left: 0;
-  border-radius: 0 0.25em 0.25em 0;
-  color: #24292f;
-  background-color: #fff;
+  color: ${(props) => (props.inverse ? styles.color.lightest : '#24292f')};
+  transition: color 0.2s ease;
 
   &:focus,
   &:hover {
-    color: #0969da;
+    color: ${(props) => (props.inverse ? styles.color.lightest : '#0969da')};
   }
 `;
 
-const Wrapper = styled.div`
-  display: flex;
-`;
-
-export const GithubButton = ({ starCount }: { starCount: number }) => (
-  <Wrapper className="chromatic-ignore">
+export const GithubButton = ({ starCount, inverse }: { starCount: number; inverse: boolean }) => (
+  <Wrapper className="chromatic-ignore" inverse={inverse}>
     <Star
       href="https://github.com/storybookjs/storybook"
       rel="noopener"
@@ -111,19 +86,20 @@ export const GithubButton = ({ starCount }: { starCount: number }) => (
         height="14"
         className="octicon octicon-mark-github"
         aria-hidden="true"
+        inverse={inverse}
       >
         <path
           fillRule="evenodd"
           d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
         />
       </Svg>
-      <span>Star</span>
     </Star>
     <Count
       href="https://github.com/storybookjs/storybook/stargazers"
       rel="noopener"
       target="_blank"
       aria-label={`${starCount} stargazers on GitHub`}
+      inverse={inverse}
     >
       {starCount.toLocaleString()}
     </Count>

--- a/src/components/GithubButton.tsx
+++ b/src/components/GithubButton.tsx
@@ -12,7 +12,7 @@ const Wrapper = styled.div<{ inverse?: boolean }>`
   border-radius: 64px;
   cursor: pointer;
   gap: 10px;
-  padding: 0 8px;
+  padding: 0 12px;
 `;
 
 const Svg = styled.svg<{ inverse?: boolean }>`

--- a/src/components/GithubButton.tsx
+++ b/src/components/GithubButton.tsx
@@ -6,8 +6,6 @@ const Wrapper = styled.div<{ inverse?: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid rgba(27, 31, 36, 0.15);
-  /* border: props.inverse ? 'rgba(255, 255, 255, 0.2)' : styles.color.border */
   border: ${(props) =>
     `1px solid ${props.inverse ? 'rgba(255, 255, 255, 0.2)' : styles.color.border}`};
   height: 32px;

--- a/src/components/IllustratedFeatureList.tsx
+++ b/src/components/IllustratedFeatureList.tsx
@@ -61,7 +61,7 @@ const IconWrapper = styled.div`
 
 const Feature = styled.button<{ inverse?: boolean }>`
   border: 1px solid ${(props) => (props.inverse ? 'rgba(255 255 255 / 10%)' : color.border)};
-  background-color: ${(props) => (props.inverse ? color.midnight : color.lightest)};
+  background-color: ${(props) => (props.inverse ? '#0E0C2A' : color.lightest)};
   border-radius: ${spacing.borderRadius.small}px;
   text-align: left;
   display: flex;

--- a/src/components/Nav/Nav.stories.tsx
+++ b/src/components/Nav/Nav.stories.tsx
@@ -82,7 +82,7 @@ export const FullStack = () => (
       link="https://storybook.js.org/blog/storybook-lazy-compilation-for-webpack/"
       githubStarCount={73724}
     />
-    <Nav apiKey="ALGOLIA_API_KEY" version="6.5" activeSection="showcase" />
+    <Nav apiKey="ALGOLIA_API_KEY" version="6.5" activeSection="showcase" githubStarCount={82000} />
     <SubNav>
       <SubNavBreadcrumb tertiary href="/back">
         <Icon icon="arrowleft" />

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -8,6 +8,7 @@ import { Search } from '../Search';
 import { TabletMenu } from './TabletMenu';
 import { MobileMenu } from './MobileMenu';
 import { LinksContext } from '../links-context';
+import { GithubButton } from '../GithubButton';
 
 const navBreakpoints = {
   desktop: 978,
@@ -76,13 +77,10 @@ const Wrapper = styled.div<{ inverse?: boolean }>`
 
 const NavContainer = styled.nav`
   ${pageMargins}
+
   display: flex;
   align-items: center;
   justify-content: space-between;
-
-  @media (min-width: ${navBreakpoints.desktop}px) {
-    justify-content: flex-start;
-  }
 `;
 
 // Tablet nav 600 - desktop
@@ -118,6 +116,7 @@ interface NavProps {
   version: string;
   apiKey: string;
   activeSection?: 'home' | 'docs' | 'showcase' | 'blog';
+  githubStarCount: number;
 }
 
 const NavLinks = styled.div`
@@ -133,78 +132,115 @@ const NavLinks = styled.div`
   }
 `;
 
+const Left = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+`;
+
+const Right = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  gap: 12px;
+`;
+
+const GithubButtonWrapper = styled.div`
+  margin-left: ${spacing.padding.medium}px;
+  flex: none;
+
+  display: none;
+
+  @media (min-width: 1024px) {
+    display: block;
+  }
+`;
+
 export const Nav: FunctionComponent<NavProps> = ({
   inverse,
   monochrome,
   version = '6.5',
   apiKey,
   activeSection = 'home',
+  githubStarCount = 8000,
 }) => {
   const navLinks = useContext(LinksContext);
 
   return (
     <Wrapper inverse={inverse}>
       <NavContainer>
-        <LogoNavItem
-          aria-label="home"
-          href={navLinks.home.url}
-          LinkWrapper={navLinks.home.linkWrapper}
-        >
-          {inverse ? (
-            <StorybookLogoInverse role="presentation" />
-          ) : (
-            <StorybookLogo role="presentation" />
-          )}
-        </LogoNavItem>
-        <NavLinks>
-          <NavItem
-            active={activeSection === 'docs'}
-            monochrome={monochrome}
-            variant={inverse ? 'inverse' : 'default'}
-            href={navLinks.guides.url}
-            LinkWrapper={navLinks.showcase.linkWrapper}
+        <Left>
+          <LogoNavItem
+            aria-label="home"
+            href={navLinks.home.url}
+            LinkWrapper={navLinks.home.linkWrapper}
           >
-            Docs
-          </NavItem>
-          <NavItem
-            active={activeSection === 'showcase'}
+            {inverse ? (
+              <StorybookLogoInverse role="presentation" />
+            ) : (
+              <StorybookLogo role="presentation" />
+            )}
+          </LogoNavItem>
+          <NavLinks>
+            <NavItem
+              active={activeSection === 'docs'}
+              monochrome={monochrome}
+              variant={inverse ? 'inverse' : 'default'}
+              href={navLinks.guides.url}
+              LinkWrapper={navLinks.showcase.linkWrapper}
+            >
+              Docs
+            </NavItem>
+            <NavItem
+              active={activeSection === 'showcase'}
+              monochrome={monochrome}
+              variant={inverse ? 'inverse' : 'default'}
+              href={navLinks.showcase.url}
+              LinkWrapper={navLinks.showcase.linkWrapper}
+            >
+              Showcase
+            </NavItem>
+            <NavItem
+              active={activeSection === 'blog'}
+              monochrome={monochrome}
+              variant={inverse ? 'inverse' : 'default'}
+              href={navLinks.blog.url}
+              LinkWrapper={navLinks.blog.linkWrapper}
+            >
+              Blog
+            </NavItem>
+            <NavItem
+              active={activeSection === 'blog'}
+              monochrome={monochrome}
+              variant={inverse ? 'inverse' : 'default'}
+              href={navLinks.chromatic.url}
+              LinkWrapper={navLinks.chromatic.linkWrapper}
+            >
+              Visual Test
+              <Arrow size={8} />
+            </NavItem>
+            <NavItem
+              monochrome={monochrome}
+              variant={inverse ? 'inverse' : 'default'}
+              href={navLinks.enterprise.url}
+              LinkWrapper={navLinks.enterprise.linkWrapper}
+            >
+              Enterprise
+              <Arrow size={8} />
+            </NavItem>
+          </NavLinks>
+        </Left>
+        <Right>
+          <GithubButtonWrapper>
+            <GithubButton starCount={githubStarCount} inverse={inverse} />
+          </GithubButtonWrapper>
+          <GlobalSearch
             monochrome={monochrome}
-            variant={inverse ? 'inverse' : 'default'}
-            href={navLinks.showcase.url}
-            LinkWrapper={navLinks.showcase.linkWrapper}
-          >
-            Showcase
-          </NavItem>
-          <NavItem
-            active={activeSection === 'blog'}
-            monochrome={monochrome}
-            variant={inverse ? 'inverse' : 'default'}
-            href={navLinks.blog.url}
-            LinkWrapper={navLinks.blog.linkWrapper}
-          >
-            Blog
-          </NavItem>
-          <NavItem
-            active={activeSection === 'blog'}
-            monochrome={monochrome}
-            variant={inverse ? 'inverse' : 'default'}
-            href={navLinks.chromatic.url}
-            LinkWrapper={navLinks.chromatic.linkWrapper}
-          >
-            Visual Test
-            <Arrow size={8} />
-          </NavItem>
-          <NavItem
-            monochrome={monochrome}
-            variant={inverse ? 'inverse' : 'default'}
-            href={navLinks.enterprise.url}
-            LinkWrapper={navLinks.enterprise.linkWrapper}
-          >
-            Enterprise
-            <Arrow size={8} />
-          </NavItem>
-        </NavLinks>
-        <GlobalSearch monochrome={monochrome} apiKey={apiKey} version={version} inverse={inverse} />
+            apiKey={apiKey}
+            version={version}
+            inverse={inverse}
+          />
+        </Right>
         {/* Collapsed navs for tablet and mobile */}
         <TabletNav navLinks={navLinks} inverse={inverse} monochrome={monochrome} />
         <MobileNav

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -66,6 +66,8 @@ const StorybookLogoInverse = styled(Logos.StorybookInverted)`
 `;
 
 const Wrapper = styled.div<{ inverse?: boolean }>`
+  position: relative;
+  z-index: 20;
   box-shadow: ${(props) => (props.inverse ? 'rgba(255, 255, 255, 0.1)' : color.tr10)} 0 -1px 0px 0px
     inset;
   padding-top: ${spacing.padding.medium}px;

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -152,7 +152,7 @@ export const Nav: FunctionComponent<NavProps> = ({
           )}
         </LogoNavItem>
         <NavLinks>
-          <NavItem
+          {/* <NavItem
             active={activeSection === 'why'}
             monochrome={monochrome}
             variant={inverse ? 'inverse' : 'default'}
@@ -160,16 +160,7 @@ export const Nav: FunctionComponent<NavProps> = ({
             LinkWrapper={navLinks.whyStorybook.linkWrapper}
           >
             Why
-          </NavItem>
-          <NavItem
-            active={activeSection === 'showcase'}
-            monochrome={monochrome}
-            variant={inverse ? 'inverse' : 'default'}
-            href={navLinks.showcase.url}
-            LinkWrapper={navLinks.showcase.linkWrapper}
-          >
-            Showcase
-          </NavItem>
+          </NavItem> */}
           <NavItem
             active={activeSection === 'docs'}
             monochrome={monochrome}
@@ -180,6 +171,15 @@ export const Nav: FunctionComponent<NavProps> = ({
             Docs
           </NavItem>
           <NavItem
+            active={activeSection === 'showcase'}
+            monochrome={monochrome}
+            variant={inverse ? 'inverse' : 'default'}
+            href={navLinks.showcase.url}
+            LinkWrapper={navLinks.showcase.linkWrapper}
+          >
+            Showcase
+          </NavItem>
+          {/* <NavItem
             active={activeSection === 'integrations'}
             monochrome={monochrome}
             variant={inverse ? 'inverse' : 'default'}
@@ -187,13 +187,13 @@ export const Nav: FunctionComponent<NavProps> = ({
             LinkWrapper={navLinks.integrations.linkWrapper}
           >
             Integrations
-          </NavItem>
-          <Community
+          </NavItem> */}
+          {/* <Community
             inverse={inverse}
             monochrome={monochrome}
             navLinks={navLinks}
             active={activeSection === 'community'}
-          />
+          /> */}
           <NavItem
             monochrome={monochrome}
             variant={inverse ? 'inverse' : 'default'}

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,10 +1,10 @@
 import React, { FunctionComponent, useContext } from 'react';
 import { styled } from '@storybook/theming';
 import { Logos } from '@storybook/design-system';
+import { ArrowTopRightIcon } from '@storybook/icons';
 import { pageMargins, spacing, color, breakpoints } from '../shared/styles';
 import { NavItem } from './NavItem';
 import { Search } from '../Search';
-import { Community } from './menus';
 import { TabletMenu } from './TabletMenu';
 import { MobileMenu } from './MobileMenu';
 import { LinksContext } from '../links-context';
@@ -107,12 +107,17 @@ const MobileNav = styled(MobileMenu)`
   }
 `;
 
+const Arrow = styled(ArrowTopRightIcon)`
+  margin-bottom: 8px;
+  margin-left: 6px;
+`;
+
 interface NavProps {
   inverse?: boolean;
   monochrome?: boolean;
   version: string;
   apiKey: string;
-  activeSection?: 'home' | 'why' | 'docs' | 'integrations' | 'showcase' | 'community';
+  activeSection?: 'home' | 'docs' | 'showcase' | 'blog';
 }
 
 const NavLinks = styled.div`
@@ -152,15 +157,6 @@ export const Nav: FunctionComponent<NavProps> = ({
           )}
         </LogoNavItem>
         <NavLinks>
-          {/* <NavItem
-            active={activeSection === 'why'}
-            monochrome={monochrome}
-            variant={inverse ? 'inverse' : 'default'}
-            href={navLinks.whyStorybook.url}
-            LinkWrapper={navLinks.whyStorybook.linkWrapper}
-          >
-            Why
-          </NavItem> */}
           <NavItem
             active={activeSection === 'docs'}
             monochrome={monochrome}
@@ -179,21 +175,25 @@ export const Nav: FunctionComponent<NavProps> = ({
           >
             Showcase
           </NavItem>
-          {/* <NavItem
-            active={activeSection === 'integrations'}
+          <NavItem
+            active={activeSection === 'blog'}
             monochrome={monochrome}
             variant={inverse ? 'inverse' : 'default'}
-            href={navLinks.integrations.url}
-            LinkWrapper={navLinks.integrations.linkWrapper}
+            href={navLinks.blog.url}
+            LinkWrapper={navLinks.blog.linkWrapper}
           >
-            Integrations
-          </NavItem> */}
-          {/* <Community
-            inverse={inverse}
+            Blog
+          </NavItem>
+          <NavItem
+            active={activeSection === 'blog'}
             monochrome={monochrome}
-            navLinks={navLinks}
-            active={activeSection === 'community'}
-          /> */}
+            variant={inverse ? 'inverse' : 'default'}
+            href={navLinks.chromatic.url}
+            LinkWrapper={navLinks.chromatic.linkWrapper}
+          >
+            Visual Test
+            <Arrow size={8} />
+          </NavItem>
           <NavItem
             monochrome={monochrome}
             variant={inverse ? 'inverse' : 'default'}
@@ -201,6 +201,7 @@ export const Nav: FunctionComponent<NavProps> = ({
             LinkWrapper={navLinks.enterprise.linkWrapper}
           >
             Enterprise
+            <Arrow size={8} />
           </NavItem>
         </NavLinks>
         <GlobalSearch monochrome={monochrome} apiKey={apiKey} version={version} inverse={inverse} />

--- a/src/components/Nav/NavItem.tsx
+++ b/src/components/Nav/NavItem.tsx
@@ -26,7 +26,6 @@ export const NavItem = styled(LinkWithWrapper, { shouldForwardProp: (prop) => pr
 
   ${(props) =>
     props.active &&
-    props.variant !== 'inverse' &&
     css`
       color: ${props.monochrome ? color.lightest : color.secondary};
       background-color: ${props.monochrome

--- a/src/components/Nav/NavItem.tsx
+++ b/src/components/Nav/NavItem.tsx
@@ -26,6 +26,7 @@ export const NavItem = styled(LinkWithWrapper, { shouldForwardProp: (prop) => pr
 
   ${(props) =>
     props.active &&
+    props.variant !== 'inverse' &&
     css`
       color: ${props.monochrome ? color.lightest : color.secondary};
       background-color: ${props.monochrome
@@ -59,6 +60,29 @@ export const NavItem = styled(LinkWithWrapper, { shouldForwardProp: (prop) => pr
             background-color: rgba(30, 167, 253, 0.07);
           }
         `}
+
+  ${(props) =>
+    props.active &&
+    props.variant === 'inverse' &&
+    css`
+      color: #fff;
+      background-color: rgba(255, 255, 255, 0.14);
+    `};
+
+  ${(props) =>
+    props.variant === 'inverse' &&
+    css`
+      &:hover,
+      &:focus {
+        color: #fff;
+        background-color: rgba(255, 255, 255, 0.14);
+      }
+
+      &:active {
+        color: #fff;
+        background-color: rgba(255, 255, 255, 0.07);
+      }
+    `};
 `;
 NavItem.defaultProps = {
   variant: 'default',

--- a/src/components/Nav/NavItem.tsx
+++ b/src/components/Nav/NavItem.tsx
@@ -60,29 +60,6 @@ export const NavItem = styled(LinkWithWrapper, { shouldForwardProp: (prop) => pr
             background-color: rgba(30, 167, 253, 0.07);
           }
         `}
-
-  ${(props) =>
-    props.active &&
-    props.variant === 'inverse' &&
-    css`
-      color: #fff;
-      background-color: rgba(255, 255, 255, 0.14);
-    `};
-
-  ${(props) =>
-    props.variant === 'inverse' &&
-    css`
-      &:hover,
-      &:focus {
-        color: #fff;
-        background-color: rgba(255, 255, 255, 0.14);
-      }
-
-      &:active {
-        color: #fff;
-        background-color: rgba(255, 255, 255, 0.07);
-      }
-    `};
 `;
 NavItem.defaultProps = {
   variant: 'default',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3133,6 +3133,11 @@
   dependencies:
     "@types/jest" ">=26.0.0"
 
+"@storybook/icons@^1.2.8":
+  version "1.2.8"
+  resolved "https://registry.npmjs.org/@storybook/icons/-/icons-1.2.8.tgz#f530688ee000b487783f2d9cf7bced92e2c32915"
+  integrity sha512-YMF5DiBvMiAVH6qd6Cf6WCwZq3D1OZNxsKtZVFBlzJXqlZb1CLEuCHy5MwL4WI5mzb6q8MJsLYpVMoH84OzUpQ==
+
 "@storybook/instrumenter@6.5.9", "@storybook/instrumenter@^6.4.0":
   version "6.5.9"
   resolved "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-6.5.9.tgz#885d9dec31b7b7fa6ea29b446105480450e527b8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,17 +140,17 @@
     "@algolia/logger-common" "4.13.1"
     "@algolia/requester-common" "4.13.1"
 
-"@auto-it/bot-list@10.37.4":
-  version "10.37.4"
-  resolved "https://registry.npmjs.org/@auto-it/bot-list/-/bot-list-10.37.4.tgz#bb1ba1d42ef6fed0ceb87279d8b7a80b12f4a163"
-  integrity sha512-Lz981mShjY7VqQpG5mAfiR7py5iH8WbEIbd2/XUQu6EQFgljj0jT6XFA180Hz1tFQJ4o2TqtXaj3gBXURhpggQ==
+"@auto-it/bot-list@11.1.1":
+  version "11.1.1"
+  resolved "https://registry.npmjs.org/@auto-it/bot-list/-/bot-list-11.1.1.tgz#944d5073a0107ab6172aa6742fa131c69d804b9a"
+  integrity sha512-uKZ08KC9FUjMBYqiizZ3VlXyEAeRHEAJaeNMqQFPi0jFKRtX/Dm4tAhDXqfQeuOuAsUHNh5Pp+4zOX2RmTPZaA==
 
-"@auto-it/core@10.37.4":
-  version "10.37.4"
-  resolved "https://registry.npmjs.org/@auto-it/core/-/core-10.37.4.tgz#8d2979d5cbb3efc8d537caecc12637fc52451219"
-  integrity sha512-QS1z+PAjXUUKuEzx56ujvhpsgLOIgCdfnj/UyNfbpVoIS+5x7ve/fhoIlkF7A2Ogrvile7EOPT0EIVmDTtzYYg==
+"@auto-it/core@11.1.1":
+  version "11.1.1"
+  resolved "https://registry.npmjs.org/@auto-it/core/-/core-11.1.1.tgz#849565aa023a0161b2134d818c9e3aaefbe27fbc"
+  integrity sha512-CIQYqJG/pXmWsQjgbjMF6qnwAu7Klrpm5fWHrXpzIEq/3qQfgGmTkauuJRSz9bM5z6pHHCjT1eypVV/EDj9ijg==
   dependencies:
-    "@auto-it/bot-list" "10.37.4"
+    "@auto-it/bot-list" "11.1.1"
     "@endemolshinegroup/cosmiconfig-typescript-loader" "^3.0.2"
     "@octokit/core" "^3.5.1"
     "@octokit/plugin-enterprise-compatibility" "1.3.0"
@@ -185,19 +185,19 @@
     tapable "^2.2.0"
     terminal-link "^2.1.1"
     tinycolor2 "^1.4.1"
-    ts-node "^9.1.1"
+    ts-node "^10.9.1"
     tslib "2.1.0"
     type-fest "^0.21.1"
     typescript-memoize "^1.0.0-alpha.3"
     url-join "^4.0.0"
 
-"@auto-it/npm@10.37.4":
-  version "10.37.4"
-  resolved "https://registry.npmjs.org/@auto-it/npm/-/npm-10.37.4.tgz#c1ff5f81138375bd3c9fc091f618a50af4df9aa8"
-  integrity sha512-nF/fZOZ6agknEiN2q9g+y+TuOsQp2f8EDRJInA0Vs/vfa22FOjIZhjJP/XAxc4ojfj/0OmKoATCQJug5PVwwYg==
+"@auto-it/npm@11.1.1":
+  version "11.1.1"
+  resolved "https://registry.npmjs.org/@auto-it/npm/-/npm-11.1.1.tgz#54f136ebb947cfc116bc0a3f4e144643f20291f9"
+  integrity sha512-I7qWPdU2goCmqdvAEpa6yGwQmzx5YXEsZywqs6uTQXIDuGbFzNt/7jwJNt8p/MNE8M0ra8FJ05eHavBLFZuEfg==
   dependencies:
-    "@auto-it/core" "10.37.4"
-    "@auto-it/package-json-utils" "10.37.4"
+    "@auto-it/core" "11.1.1"
+    "@auto-it/package-json-utils" "11.1.1"
     await-to-js "^3.0.0"
     endent "^2.1.0"
     env-ci "^5.0.1"
@@ -211,32 +211,32 @@
     url-join "^4.0.0"
     user-home "^2.0.0"
 
-"@auto-it/package-json-utils@10.37.4":
-  version "10.37.4"
-  resolved "https://registry.npmjs.org/@auto-it/package-json-utils/-/package-json-utils-10.37.4.tgz#8ca6209e5a2f217c458d2887ca0a9f52450cd7db"
-  integrity sha512-LLVtEeuAOeDQmhkDEOJyGU9PFdF5i46UcS7vG7BxSLQg2UAhvAolLgD/u6wOTOCDmQnLsBP6hdStSbHjDO8tMg==
+"@auto-it/package-json-utils@11.1.1":
+  version "11.1.1"
+  resolved "https://registry.npmjs.org/@auto-it/package-json-utils/-/package-json-utils-11.1.1.tgz#b7e086ce394b14d674d1c89b8e384f23598695a9"
+  integrity sha512-hk6wKuP7fPonXnP/blPHYS4iQaKZ6s+dVBRPSW7pjWZv6H/A131mWVSQC59nhe8lqZhbQ2MrDH4xxfhYnq21sA==
   dependencies:
     parse-author "^2.0.0"
     parse-github-url "1.0.2"
 
-"@auto-it/released@10.37.4":
-  version "10.37.4"
-  resolved "https://registry.npmjs.org/@auto-it/released/-/released-10.37.4.tgz#10d82f1faa08f98a7709b76ae23a1e03c6a3b505"
-  integrity sha512-1l4gRs/Cb3G6wsIwlxfoIp8OBl/WyAF2Lj5OmZ5Tbjfr6Mki6wD9xxa95rrXG47vaY+u+jcqNYX2dwP2ROxOhA==
+"@auto-it/released@11.1.1":
+  version "11.1.1"
+  resolved "https://registry.npmjs.org/@auto-it/released/-/released-11.1.1.tgz#483a2d6e3b7e0fe8bc9d29c57bb7fbd40ca36b40"
+  integrity sha512-iRUebl2q5V7hFEgScGVUMUVoOXrFFi5O280hUCpZxmd6kkG2v7Kl+Weii5zKpd7YSqG0HibJCD+LVwPClAfrCA==
   dependencies:
-    "@auto-it/bot-list" "10.37.4"
-    "@auto-it/core" "10.37.4"
+    "@auto-it/bot-list" "11.1.1"
+    "@auto-it/core" "11.1.1"
     deepmerge "^4.0.0"
     fp-ts "^2.5.3"
     io-ts "^2.1.2"
     tslib "2.1.0"
 
-"@auto-it/version-file@10.37.4":
-  version "10.37.4"
-  resolved "https://registry.npmjs.org/@auto-it/version-file/-/version-file-10.37.4.tgz#51b46f9a7f03d58566c6b47c2a9e8ddeae65088c"
-  integrity sha512-CnYgo6GNgBcMDrkoeeHMG3PRDpYZ84pUZehoqZmXKczGzXEJSulHdedmPvuAW3rEvVAFJhWPRcJ10ByRkIQoBg==
+"@auto-it/version-file@11.1.1":
+  version "11.1.1"
+  resolved "https://registry.npmjs.org/@auto-it/version-file/-/version-file-11.1.1.tgz#3642728e9119672193408f45b5ae96e58b72ef66"
+  integrity sha512-KHKunip2nXWKd7zJ0hdALojY+E6sTdmxuq9SXYgTMXUcZw2BtxunVSK1hb2wmS6iUH4CCILk12dHksAO5BFzeQ==
   dependencies:
-    "@auto-it/core" "10.37.4"
+    "@auto-it/core" "11.1.1"
     fp-ts "^2.5.3"
     io-ts "^2.1.2"
     semver "^7.0.0"
@@ -1586,6 +1586,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@design-systems/utils@2.12.0":
   version "2.12.0"
   resolved "https://registry.npmjs.org/@design-systems/utils/-/utils-2.12.0.tgz#955c108be07cb8f01532207cbfea8f848fa760c9"
@@ -1895,6 +1902,14 @@
   version "1.4.13"
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz#b6461fb0c2964356c469e115f504c95ad97ab88c"
   integrity sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.13"
@@ -3598,6 +3613,26 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
 "@types/aria-query@^4.2.0":
   version "4.2.2"
   resolved "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
@@ -4325,6 +4360,11 @@ acorn-walk@^7.2.0:
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.3.2"
+  resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz#7703af9415f1b6db9315d6895503862e231d34aa"
+  integrity sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==
+
 acorn@^6.4.1:
   version "6.4.2"
   resolved "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
@@ -4837,15 +4877,15 @@ author-regex@^1.0.0:
   resolved "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
   integrity sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA=
 
-auto@^10.37.4:
-  version "10.37.4"
-  resolved "https://registry.npmjs.org/auto/-/auto-10.37.4.tgz#450a9d51166919a97ea85fa06d117ecd94adb9ff"
-  integrity sha512-chspNHfy17DFOPwLbT74xU+fD0NXhtLpWnKZjoLjHUKp0+ZNJSM9jrBHq2ExB4EAP3UXlFVDG+BzrkgZoYLzCw==
+auto@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.npmjs.org/auto/-/auto-11.1.1.tgz#874681d990c567208457a1f30d207b3df1484bd5"
+  integrity sha512-mOucdDWMjtuBDH8phH9Z0s1dD4uFrFIhYQ/Zh4wCH2uB3eEf8qZbu20DLOWCfj1zEUU2gxqVAuqJD4OyLWvaSQ==
   dependencies:
-    "@auto-it/core" "10.37.4"
-    "@auto-it/npm" "10.37.4"
-    "@auto-it/released" "10.37.4"
-    "@auto-it/version-file" "10.37.4"
+    "@auto-it/core" "11.1.1"
+    "@auto-it/npm" "11.1.1"
+    "@auto-it/released" "11.1.1"
+    "@auto-it/version-file" "11.1.1"
     await-to-js "^3.0.0"
     chalk "^4.0.0"
     command-line-application "^0.10.1"
@@ -14103,7 +14143,26 @@ ts-loader@^7.0.5:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
-ts-node@^9, ts-node@^9.1.1:
+ts-node@^10.9.1:
+  version "10.9.2"
+  resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
+ts-node@^9:
   version "9.1.1"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
   integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
@@ -14636,6 +14695,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
We updated Storybook's homepage to use a new design that require some changes on the main nav and footer mostly.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.3.1--canary.74.9140eb1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.3.1--canary.74.9140eb1.0
  # or 
  yarn add @storybook/components-marketing@2.3.1--canary.74.9140eb1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
