### PR TITLE
Update Github button link

### DIFF
--- a/src/components/GithubButton.tsx
+++ b/src/components/GithubButton.tsx
@@ -93,10 +93,10 @@ export const GithubButton = ({ starCount, inverse }: { starCount: number; invers
       </Svg>
     </Star>
     <Count
-      href="https://github.com/storybookjs/storybook/stargazers"
+      href="https://github.com/storybookjs/storybook"
       rel="noopener"
       target="_blank"
-      aria-label={`${starCount} stargazers on GitHub`}
+      aria-label="Storybook on GitHub"
       inverse={inverse}
     >
       {starCount.toLocaleString()}


### PR DESCRIPTION
In this PR we are changing the link to Github to point directly to the core repo instead of the list of stargazers.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.3.2--canary.76.fa52690.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@2.3.2--canary.76.fa52690.0
  # or 
  yarn add @storybook/components-marketing@2.3.2--canary.76.fa52690.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
