### PR TITLE
Remove status page link from Footer

### DIFF
--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -31,7 +31,6 @@ const links = {
   tutorials: { url: 'https://storybook.js.org/tutorials' },
   changelog: { url: '/releases', linkWrapper: FakeGatsbyLink },
   telemetry: { url: '/telemetry', linkWrapper: FakeGatsbyLink },
-  status: { url: 'https://storybook.js.org/status' },
   showcase: { url: 'https://storybook.js.org/showcase' },
   projects: { url: 'https://storybook.js.org/showcase/projects' },
   componentGlossary: { url: 'https://storybook.js.org/showcase/glossary' },
@@ -39,6 +38,12 @@ const links = {
   getInvolved: { url: '/community', linkWrapper: FakeGatsbyLink },
   blog: { url: 'https://storybook.js.org/blog' },
   hiring: { url: 'https://www.chromatic.com/company/jobs' },
+  enterprise: {
+    url: 'https://www.chromatic.com/sales?utm_source=storybook_website&utm_medium=link&utm_campaign=storybook',
+  },
+  chromatic: {
+    url: 'https://www.chromatic.com/storybook?utm_source=storybook_website&utm_medium=link&utm_campaign=storybook',
+  },
 };
 
 const Template = (args) => (

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -25,7 +25,6 @@ const footerGroups = (links: Links) => ({
     { label: 'Tutorials', link: links.tutorials },
     { label: 'Changelog', link: links.changelog },
     { label: 'Telemetry', link: links.telemetry },
-    { label: 'Status', link: links.status },
   ],
   community: [
     { label: 'Addons', link: links.integrations },

--- a/src/components/links-context.ts
+++ b/src/components/links-context.ts
@@ -13,7 +13,6 @@ export interface Links {
   tutorials: LinkItem;
   changelog: LinkItem;
   telemetry: LinkItem;
-  status: LinkItem;
   showcase: LinkItem;
   projects: LinkItem;
   componentGlossary: LinkItem;
@@ -33,7 +32,6 @@ export const defaultLinks = {
   tutorials: { url: 'https://storybook.js.org/tutorials' },
   changelog: { url: 'https://storybook.js.org/releases' },
   telemetry: { url: 'https://storybook.js.org/telemetry' },
-  status: { url: 'https://storybook.js.org/status' },
   showcase: { url: 'https://storybook.js.org/showcase' },
   projects: { url: 'https://storybook.js.org/showcase/projects' },
   componentGlossary: { url: 'https://storybook.js.org/showcase/glossary' },


### PR DESCRIPTION
See also: https://github.com/storybookjs/frontpage/pull/700
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.1.1--canary.81.f7bb1cc.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/components-marketing@3.1.1--canary.81.f7bb1cc.0
  # or 
  yarn add @storybook/components-marketing@3.1.1--canary.81.f7bb1cc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
